### PR TITLE
Add JSON-LD and yml2vocab vocab file.

### DIFF
--- a/context.json
+++ b/context.json
@@ -1,0 +1,129 @@
+{
+  "@context": {
+    "http://www.w3.org/2001/XMLSchema#": "http://www.w3.org/2001/XMLSchema#",
+
+    "description": {
+      "@id": "https://schema.org/description",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+
+    "identifier": {
+      "@id": "https://schema.org/identifier",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+
+    "category": {
+      "@id": "https://schema.org/category",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+
+    "CapabilityManifest": {
+      "@id": "https://example.com/ontology/CapabilityManifest",
+      "@context": {
+        "@protected": true,
+        "protocol_version": {
+          "@id": "https://schema.org/version",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "capabilities": {
+          "@id": "https://schema.org/featureList",
+          "@container": "@set",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "extensions": {
+          "@id": "https://schema.org/additionalProperty",
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+        }
+      }
+    },
+
+    "WorkflowContext": {
+      "@id": "https://example.com/ontology/WorkflowContext",
+      "@context": {
+        "@protected": true,
+        "workflow_id": {
+          "@id": "https://schema.org/identifier",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "business_rules": {
+          "@id": "https://schema.org/conditionsOfAccess",
+          "@container": "@set",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "historical_incidents": {
+          "@id": "https://example.com/ontology/historicalIncidents",
+          "@container": "@set",
+          "@type": "@id"
+        },
+        "incident_id": {
+          "@id": "https://schema.org/identifier",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "root_cause": {
+          "@id": "https://schema.org/cause",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "test_coverage_percentage": {
+          "@id": "https://schema.org/measurementTechnique",
+          "@type": "http://www.w3.org/2001/XMLSchema#float"
+        }
+      }
+    },
+
+    "RiskAssessmentRequest": {
+      "@id": "https://example.com/ontology/RiskAssessmentRequest",
+      "@context": {
+        "@protected": true,
+        "target_branch": {
+          "@id": "https://schema.org/branch",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "diff_payload": {
+          "@id": "https://schema.org/codeSampleType",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "associated_tickets": {
+          "@id": "https://schema.org/identifier",
+          "@container": "@set",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      }
+    },
+
+    "RiskAssessmentResponse": {
+      "@id": "https://example.com/ontology/RiskAssessmentResponse",
+      "@context": {
+        "@protected": true,
+        "risk_score": {
+          "@id": "https://schema.org/ratingValue",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "impacted_workflows": {
+          "@id": "https://schema.org/affectedBy",
+          "@container": "@set",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "missing_coverage": {
+          "@id": "https://example.com/ontology/missingCoverage",
+          "@container": "@set",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      }
+    },
+
+    "ExecutionRequest": {
+      "@id": "https://example.com/ontology/ExecutionRequest",
+      "@context": {
+        "@protected": true,
+        "target": {
+          "@id": "https://schema.org/about",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "green_contract_level": {
+          "@id": "https://schema.org/category",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      }
+    }
+  }
+}

--- a/context/vocab.yaml
+++ b/context/vocab.yaml
@@ -1,0 +1,95 @@
+vocabulary: https://example.com/ontology/
+prefixes:
+  schema: https://schema.org/
+  xsd: http://www.w3.org/2001/XMLSchema#
+
+classes:
+  CapabilityManifest:
+    iri: https://example.com/ontology/CapabilityManifest
+    label: Capability Manifest
+    properties:
+      protocol_version:
+        iri: https://schema.org/version
+        range: xsd:string
+      capabilities:
+        iri: https://schema.org/featureList
+        range: xsd:string
+        container: set
+      extensions:
+        iri: https://schema.org/additionalProperty
+        range: xsd:boolean
+
+  WorkflowContext:
+    iri: https://example.com/ontology/WorkflowContext
+    label: Workflow Context
+    properties:
+      workflow_id:
+        iri: https://schema.org/identifier
+        range: xsd:string
+      description:
+        iri: https://schema.org/description
+        range: xsd:string
+      business_rules:
+        iri: https://schema.org/conditionsOfAccess
+        range: xsd:string
+        container: set
+      historical_incidents:
+        iri: https://example.com/ontology/historicalIncidents
+        range: WorkflowIncident
+        container: set
+      test_coverage_percentage:
+        iri: https://schema.org/measurementTechnique
+        range: xsd:float
+
+  WorkflowIncident:
+    iri: https://example.com/ontology/WorkflowIncident
+    label: Workflow Incident
+    properties:
+      incident_id:
+        iri: https://schema.org/identifier
+        range: xsd:string
+      root_cause:
+        iri: https://schema.org/cause
+        range: xsd:string
+
+  RiskAssessmentRequest:
+    iri: https://example.com/ontology/RiskAssessmentRequest
+    label: Risk Assessment Request
+    properties:
+      target_branch:
+        iri: https://schema.org/branch
+        range: xsd:string
+      diff_payload:
+        iri: https://schema.org/codeSampleType
+        range: xsd:string
+      associated_tickets:
+        iri: https://schema.org/identifier
+        range: xsd:string
+        container: set
+
+  RiskAssessmentResponse:
+    iri: https://example.com/ontology/RiskAssessmentResponse
+    label: Risk Assessment Response
+    properties:
+      risk_score:
+        iri: https://schema.org/ratingValue
+        range: xsd:string
+      impacted_workflows:
+        iri: https://schema.org/affectedBy
+        range: xsd:string
+        container: set
+      missing_coverage:
+        iri: https://example.com/ontology/missingCoverage
+        range: xsd:string
+        container: set
+
+  ExecutionRequest:
+    iri: https://example.com/ontology/ExecutionRequest
+    label: Execution Request
+    properties:
+      target:
+        iri: https://schema.org/about
+        range: xsd:string
+      green_contract_level:
+        iri: https://schema.org/category
+        range: xsd:string


### PR DESCRIPTION
Rather drafty, but it's a start. Most of this was generated in a short session with https://copilot.microsoft.com/

So...it also needs some testing. :grin:

The `vocab.yaml` file can (or at least in theory can...) be used with https://github.com/w3c/yml2vocab to generate that same context as part of a build pipeline.

I intend to come back and test more of this setup (and the context).

If you have example JSON for any/all of the objects, that would give us more to test the context with.

Hope this helps!

Fixes #3